### PR TITLE
font-family for console style

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -128,8 +128,8 @@ div.term div.jquery-console-message-error {
 
 div.term div.jquery-console-message-success {
   color: #09f753;
-  font-family: monospace;
-  padding: 0.1em;
+  font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
+  padding: .1em;
   white-space: pre;
 }
 


### PR DESCRIPTION
Hello !

I like the console style of tour.tidb.io. But unfortunately there seems to be some problems with the table drawing.

before  : 
![image](https://user-images.githubusercontent.com/689799/96728413-0f50d800-13ef-11eb-9223-9f5a25f5a651.png)

after : 
![image](https://user-images.githubusercontent.com/689799/96728554-33141e00-13ef-11eb-9e59-17b8fbef9bad.png)

This font-family is from the MarkDown element on the same page.
PS： I am running on Google Chrome 86.0.4240.75 (MacOS Catalina 10.15.7 ).